### PR TITLE
FastScroll thumb drag listener, and show/hide animation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.0'
         // Do not place application dependencies here.
         // They belong in the individual module build.gradle files
     }
@@ -22,5 +23,5 @@ ext {
     targetSdkVersion = 21
     minSdkVersion = 14
     versionCode = 3
-    versionName = "0.1.3"
+    versionName = "0.1.4"
 }

--- a/recyclerviewfastscroller/build.gradle
+++ b/recyclerviewfastscroller/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: "com.jfrog.artifactory"
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion as Integer
@@ -22,8 +23,8 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-v4:22.1.0"
-    compile "com.android.support:recyclerview-v7:22.1.0"
+    compile "com.android.support:support-v4:22.2.0"
+    compile "com.android.support:recyclerview-v7:22.2.0"
 }
 
 def uploadScriptPropertyName = "recyclerviewfastscroller.uploadScript"
@@ -36,4 +37,35 @@ if (project.hasProperty(uploadScriptPropertyName)
     afterEvaluate {
         androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
     }
+}
+
+// Variables for Artifactory publishing are stored in local gradle.properties
+artifactory {
+    contextUrl = "${artifactory_contextUrl}"
+    publish {
+        repository {
+            repoKey = "${artifactory_repokey}"
+            username = "${artifactory_user}"
+            password = "${artifactory_password}"
+            maven = true
+        }
+        defaults {
+            publications ('recyclerviewfastscroller')
+        }
+    }
+}
+
+publishing {
+    publications {
+        recyclerviewfastscroller(MavenPublication) {
+            groupId 'com.brightcove'
+            artifactId 'recyclerviewfastscroller'
+            version rootProject.ext.versionName as String
+            artifact("$buildDir/outputs/aar/recyclerviewfastscroller-release.aar")
+        }
+    }
+}
+
+artifactoryPublish {
+    dependsOn assemble
 }

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -38,7 +38,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     private static final int DURATION_FADE_IN = 150;
     private static final int DURATION_FADE_OUT = 300;
     private static final int FADE_TIMEOUT = 1500;
-    private MediaHandler mHandler;
+    private HideHandler mHideHandler;
 
     private static final int[] STYLEABLE = R.styleable.AbsRecyclerViewFastScroller;
     /** The long bar along which a handle travels */
@@ -91,7 +91,7 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
         } finally {
             attributes.recycle();
         }
-        mHandler = new MediaHandler(this);
+        mHideHandler = new HideHandler(this);
         setOnTouchListener(new FastScrollerTouchListener(this));
     }
 
@@ -292,17 +292,17 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
             .alpha(1f)
             .setDuration(DURATION_FADE_IN);
 
-        Message msg = mHandler.obtainMessage(1);
-        mHandler.removeMessages(1);
+        Message msg = mHideHandler.obtainMessage(1);
+        mHideHandler.removeMessages(1);
         if (timeout != 0) {
-            mHandler.sendMessageDelayed(msg, timeout);
+            mHideHandler.sendMessageDelayed(msg, timeout);
         }
     }
 
-    static class MediaHandler extends Handler {
+    static class HideHandler extends Handler {
         private final WeakReference<AbsRecyclerViewFastScroller> weakReference;
 
-        MediaHandler(AbsRecyclerViewFastScroller scroller) {
+        HideHandler(AbsRecyclerViewFastScroller scroller) {
             weakReference = new WeakReference<>(scroller);
         }
 

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -36,6 +36,8 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
     /** The handle that signifies the user's progress in the list */
     protected final View mHandle;
 
+    protected FastScrollListener mFastScrollListener;
+
     /* TODO:
      *      Consider making RecyclerView final and should be passed in using a custom attribute
      *      This could allow for some type checking on the section indicator wrt the adapter of the RecyclerView
@@ -88,6 +90,20 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
             setViewBackground(view, drawable);
         } else {
             view.setBackgroundColor(color);
+        }
+    }
+
+    public interface FastScrollListener {
+        void notifyScrollState(boolean scrolling);
+    }
+
+    public void setFastScrollListener(FastScrollListener fastScrollListener) {
+        mFastScrollListener = fastScrollListener;
+    }
+
+    public void notifyScrollState(boolean scrolling) {
+        if (mFastScrollListener != null) {
+            mFastScrollListener.notifyScrollState(scrolling);
         }
     }
 

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -299,12 +299,6 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
         }
     }
 
-    public void hide() {
-        animate()
-            .alpha(0f)
-            .setDuration(DURATION_FADE_OUT);
-    }
-
     static class MediaHandler extends Handler {
         private final WeakReference<AbsRecyclerViewFastScroller> weakReference;
 
@@ -318,7 +312,9 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
                 case 1:
                     AbsRecyclerViewFastScroller scroller = weakReference.get();
                     if (scroller == null) break;
-                    scroller.hide();
+                    scroller.animate()
+                            .alpha(0f)
+                            .setDuration(DURATION_FADE_OUT);
                     break;
             }
         }

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/AbsRecyclerViewFastScroller.java
@@ -78,6 +78,9 @@ public abstract class AbsRecyclerViewFastScroller extends FrameLayout implements
             LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             inflater.inflate(layoutResource, this, true);
 
+            // Default to hiding the view so it can be shown on scroll and hidden again
+            setAlpha(0);
+
             mBar = findViewById(R.id.scroll_bar);
             mHandle = findViewById(R.id.scroll_handle);
 

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
@@ -33,18 +33,16 @@ class FastScrollerTouchListener implements OnTouchListener {
     }
 
     private void showOrHideIndicator(@Nullable SectionIndicator sectionIndicator, MotionEvent event) {
-        if (sectionIndicator == null) {
-            return;
-        }
-
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
                 mFastScroller.notifyScrollState(true);
-                sectionIndicator.animateAlpha(1f);
+                if (sectionIndicator != null)
+                    sectionIndicator.animateAlpha(1f);
                 return;
             case MotionEvent.ACTION_UP:
                 mFastScroller.notifyScrollState(false);
-                sectionIndicator.animateAlpha(0f);
+                if (sectionIndicator != null)
+                    sectionIndicator.animateAlpha(0f);
         }
     }
 

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
@@ -45,5 +45,4 @@ class FastScrollerTouchListener implements OnTouchListener {
                     sectionIndicator.animateAlpha(0f);
         }
     }
-
 }

--- a/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
+++ b/recyclerviewfastscroller/src/main/java/xyz/danoz/recyclerviewfastscroller/FastScrollerTouchListener.java
@@ -39,9 +39,11 @@ class FastScrollerTouchListener implements OnTouchListener {
 
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_DOWN:
+                mFastScroller.notifyScrollState(true);
                 sectionIndicator.animateAlpha(1f);
                 return;
             case MotionEvent.ACTION_UP:
+                mFastScroller.notifyScrollState(false);
                 sectionIndicator.animateAlpha(0f);
         }
     }


### PR DESCRIPTION
It's not hidden by default, but by setting `android:alpha` to 0 on the FastScroller in XML then a standard hide/show pattern is attained. I grabbed the animation timings from the AOSP FastScroller widget, and the animation mechanism from Tina.
I can try to look into hiding it by default too? This seems to work well at any rate.
